### PR TITLE
Frequency rise to 50Hz

### DIFF
--- a/lib/Glove/Glove.cpp
+++ b/lib/Glove/Glove.cpp
@@ -12,7 +12,7 @@ const int Glove::UNKNOWN_ERROR = 4;
 const int Glove::kI2cSpeedHertz = 400000;
 
 void Glove::init() {
-  Wire.begin(kSdaPin, kSclPin, kI2cSpeedHertz);
+  Wire.begin(kSdaPin, kSclPin);
   setUpSensors();
 }
 

--- a/lib/Glove/Glove.cpp
+++ b/lib/Glove/Glove.cpp
@@ -12,7 +12,7 @@ const int Glove::UNKNOWN_ERROR = 4;
 const int Glove::kI2cSpeedHertz = 400000;
 
 void Glove::init() {
-  Wire.begin(kSdaPin, kSclPin);
+  Wire.begin(kSdaPin, kSclPin, kI2cSpeedHertz);
   setUpSensors();
 }
 

--- a/lib/Glove/Mpu.cpp
+++ b/lib/Glove/Mpu.cpp
@@ -25,19 +25,10 @@ Mpu::Mpu(const Finger::Value &finger)
 
 void Mpu::beginCommunication() {
   digitalWrite(this->ad0_, LOW);
-
-  // while (digitalRead(this->ad0_) != LOW) {
-  //   digitalWrite(this->ad0_, LOW);
-  //   // delay(20);
-  // }
 }
 
 void Mpu::endCommunication() {
   digitalWrite(this->ad0_, HIGH);
-  // while (digitalRead(this->ad0_) != HIGH) {
-  //   digitalWrite(this->ad0_, HIGH);
-  //   // delay(20);
-  // }
 }
 
 
@@ -196,11 +187,6 @@ void Mpu::log() { log_d("%s", Finger::getName(this->finger_).c_str()); }
 void Mpu::setWriteMode() {
   pinMode(this->ad0_, OUTPUT);
   digitalWrite(this->ad0_, HIGH);
-
-  // while (digitalRead(this->ad0_) != HIGH) {
-  //   digitalWrite(this->ad0_, HIGH);
-  //   // delay(20);
-  // }
 }
 
 Finger::Value Mpu::getFinger() { return this->finger_; }

--- a/lib/Glove/Mpu.cpp
+++ b/lib/Glove/Mpu.cpp
@@ -24,17 +24,20 @@ Mpu::Mpu(const Finger::Value &finger)
       previousTime_(millis()) {}
 
 void Mpu::beginCommunication() {
-  while (digitalRead(this->ad0_) != LOW) {
-    digitalWrite(this->ad0_, LOW);
-    delay(20);
-  }
+  digitalWrite(this->ad0_, LOW);
+
+  // while (digitalRead(this->ad0_) != LOW) {
+  //   digitalWrite(this->ad0_, LOW);
+  //   // delay(20);
+  // }
 }
 
 void Mpu::endCommunication() {
-  while (digitalRead(this->ad0_) != HIGH) {
-    digitalWrite(this->ad0_, HIGH);
-    delay(20);
-  }
+  digitalWrite(this->ad0_, HIGH);
+  // while (digitalRead(this->ad0_) != HIGH) {
+  //   digitalWrite(this->ad0_, HIGH);
+  //   // delay(20);
+  // }
 }
 
 
@@ -192,10 +195,12 @@ void Mpu::log() { log_d("%s", Finger::getName(this->finger_).c_str()); }
 
 void Mpu::setWriteMode() {
   pinMode(this->ad0_, OUTPUT);
-  while (digitalRead(this->ad0_) != HIGH) {
-    digitalWrite(this->ad0_, HIGH);
-    delay(20);
-  }
+  digitalWrite(this->ad0_, HIGH);
+
+  // while (digitalRead(this->ad0_) != HIGH) {
+  //   digitalWrite(this->ad0_, HIGH);
+  //   // delay(20);
+  // }
 }
 
 Finger::Value Mpu::getFinger() { return this->finger_; }

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@
 platform = espressif32
 board = esp32doit-devkit-v1
 framework = arduino
-build_flags = -DCORE_DEBUG_LEVEL=3 ; to remove logs change this to 0
+build_flags = -DCORE_DEBUG_LEVEL=0 ; to remove logs change this to 0
 lib_extra_dirs = ~/Documents/Arduino/libraries
 lib_deps = arduino-libraries/Arduino_JSON@^0.1.0
 monitor_filters = esp32_exception_decoder

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,7 +137,8 @@ void loop() {}  // loop() runs on core 1
       elapsedTime = currentTime - prevTime;
       GloveMeasurements measurements = glove.readSensors(elapsedTime);
       log_i("frequency: %.3f hz", 1.0 /(elapsedTime/1000.0));// Divide by 1000 to get seconds
-      xQueueSend(queue, &measurements, portMAX_DELAY);
+      bleCommunicator.sendMeasurements(measurements);
+      // xQueueSend(queue, &measurements, portMAX_DELAY);
       prevTime = currentTime;
     }
   }


### PR DESCRIPTION
En este PR se hacen cambios en la arquitectura para poder incrementar la frecuencia de toma de mediciones de 5Hz a 50Hz, eliminando la task de comunicación mediante BLE y realizando las transmisiones en la misma task de recolección de datos, evitando de este modo tener que encolar y desencolar instancias de glove measurements para pasar de una task a la otra, lo cual estaba causando que sin los delays (ahora eliminados) el guante crasheara por problemas de memoria.

Queda pendiente intentar elevar la frecuencia del bus i2c a 400KHz, lo cual ha sido infructuoso hasta el momento.